### PR TITLE
fix(cmd): Persist identity & improve missing identity errors

### DIFF
--- a/cloudflare/identity.go
+++ b/cloudflare/identity.go
@@ -41,7 +41,7 @@ func CreateOrUpdateIdentity(license string) (*model.Identity, error) {
 		identity.Account = iAcc
 	}
 
-	return &identity, nil
+	return identity, nil
 }
 
 func LoadOrCreateIdentity() (*model.Identity, error) {
@@ -58,34 +58,34 @@ func LoadOrCreateIdentity() (*model.Identity, error) {
 	return identity, nil
 }
 
-func LoadIdentity() (model.Identity, error) {
+func LoadIdentity() (*model.Identity, error) {
 	regPath := model.GetRegPath()
 	confPath := model.GetConfPath()
 
 	if _, err := os.Stat(regPath); os.IsNotExist(err) {
-		return model.Identity{}, err
+		return nil, err
 	}
 	if _, err := os.Stat(confPath); os.IsNotExist(err) {
-		return model.Identity{}, err
+		return nil, err
 	}
 
 	regBytes, err := os.ReadFile(regPath)
 	if err != nil {
-		return model.Identity{}, err
+		return nil, err
 	}
 	confBytes, err := os.ReadFile(confPath)
 	if err != nil {
-		return model.Identity{}, err
+		return nil, err
 	}
 
 	var regFile model.RegFile
 	if err := json.Unmarshal(regBytes, &regFile); err != nil {
-		return model.Identity{}, err
+		return nil, err
 	}
 
 	var confFile model.ConfFile
 	if err := json.Unmarshal(confBytes, &confFile); err != nil {
-		return model.Identity{}, err
+		return nil, err
 	}
 
 	identity := model.Identity{
@@ -98,10 +98,10 @@ func LoadIdentity() (model.Identity, error) {
 	}
 
 	if len(identity.Config.Peers) < 1 {
-		return model.Identity{}, errors.New("identity contains 0 peers")
+		return nil, errors.New("identity contains 0 peers")
 	}
 
-	return identity, nil
+	return &identity, nil
 }
 
 func CreateIdentity(warpAPI *WarpAPI, license string) (model.Identity, error) {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,7 +21,7 @@ var GenerateCmd = &cobra.Command{
 func init() {}
 
 func generate(cmd *cobra.Command, args []string) {
-	ident, err := cloudflare.CreateOrUpdateIdentity("")
+	ident, err := cloudflare.LoadOrCreateIdentity()
 	if err != nil {
 		log.Fatalw("Failed to generate primary identity", zap.Error(err))
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"log"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +27,9 @@ var StatusCmd = &cobra.Command{
 func status() error {
 	identity, err := cloudflare.LoadIdentity()
 	if err != nil {
+		if os.IsNotExist(err) || errors.Is(err, errors.New("identity contains 0 peers")) {
+			return fmt.Errorf("WARP identity not found. Please run 'warp generate' to create one")
+		}
 		return err
 	}
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -41,6 +43,9 @@ func runUpdate() error {
 
 	identity, err := cloudflare.LoadIdentity()
 	if err != nil {
+		if os.IsNotExist(err) || errors.Is(err, errors.New("identity contains 0 peers")) {
+			return fmt.Errorf("WARP identity not found. Please run 'warp generate' to create one")
+		}
 		return err
 	}
 
@@ -60,7 +65,7 @@ func runUpdate() error {
 	// Update license if provided
 	if license != "" {
 		// Generate configs
-		_, err = cloudflare.CreateOrUpdateIdentity(license)
+		identity, err = cloudflare.CreateOrUpdateIdentity(license)
 		if err != nil {
 			log.Fatalw("Failed to generate primary identity", zap.Error(err))
 		}


### PR DESCRIPTION
Ensures `generate` and `update` commands persist WARP identity. Adds user-friendly errors for `status` and `update` when identity files are missing.