### PR TITLE
Adding SDK for that project

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,82 @@ These files are automatically managed by the `warp` commands (e.g., `generate`, 
 
 The project is in active development, and performance is a continuous focus. While the official client leverages highly optimized implementations, `cloudflare-warp` aims to provide a robust user-space solution. Performance can vary based on network conditions and system resources.
 
+## Go SDK
+
+Package `sdk` embeds WARP proxies in another Go application. One client loads or
+creates the WARP identity once; each proxy gets an independent userspace tunnel,
+local port, and remote WARP endpoint IP.
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"net/netip"
+	"time"
+
+	warpsdk "github.com/shahradelahi/cloudflare-warp/sdk"
+)
+
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Loads an existing identity or generates reg.json/conf.json here.
+	client, err := warpsdk.GenerateIdentity("/var/lib/my-app/warp")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	endpoints, err := client.Scan(ctx, warpsdk.ScanOptions{
+		IPv4:   true,
+		Limit:  2,
+		MaxRTT: 500 * time.Millisecond,
+		Timeout: time.Minute,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	proxies := make([]*warpsdk.Proxy, 0, len(endpoints))
+	for i, endpoint := range endpoints {
+		proxy, err := client.NewProxy(ctx, warpsdk.ProxyConfig{
+			ListenIP:   netip.MustParseAddr("127.0.0.1"),
+			Port:       uint16(1080 + i),
+			EndpointIP: endpoint.AddrPort.Addr(),
+			EndpointPort: endpoint.AddrPort.Port(),
+			// Protocol defaults to warpsdk.SOCKS5.
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := proxy.Start(); err != nil {
+			log.Fatal(err)
+		}
+		proxies = append(proxies, proxy)
+	}
+
+	<-ctx.Done()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	for _, proxy := range proxies {
+		if err := proxy.Shutdown(shutdownCtx); err != nil {
+			log.Printf("proxy shutdown: %v", err)
+		}
+	}
+}
+```
+
+`Scan` performs real WARP WireGuard handshakes and returns endpoints ordered by
+RTT. `CheckEndpoint` checks one exact `netip.AddrPort`. `Start` is asynchronous;
+use `Wait` or `WaitContext` to receive startup/runtime errors. `Shutdown` stops
+one proxy and waits for its listener and tunnel. Use `Run` when a blocking call
+is more convenient. Set `Protocol` to
+`warpsdk.HTTP` for an HTTP CONNECT proxy. By default listeners bind only to
+`127.0.0.1`; exposing a proxy via `0.0.0.0` or `::` should be done only with
+appropriate network access controls.
+
 ## 💬 Community
 
 Welcome and feel free to ask any questions at [Discussions](https://github.com/shahradelahi/cloudflare-warp/discussions).

--- a/core/config.go
+++ b/core/config.go
@@ -2,6 +2,8 @@ package core
 
 import (
 	"net/netip"
+
+	"github.com/shahradelahi/cloudflare-warp/cloudflare/model"
 )
 
 // Config holds the configuration for the WARP engine.
@@ -12,4 +14,7 @@ type Config struct {
 	DnsAddr              netip.Addr
 	Scan                 *ScanOptions
 	UserProvidedEndpoint bool
+	// Identity overrides identity loading from the global data directory.
+	// It allows embedded applications to reuse an identity across proxies.
+	Identity *model.Identity
 }

--- a/core/engine.go
+++ b/core/engine.go
@@ -72,8 +72,6 @@ func (e *Engine) Run() error {
 					return err
 				}
 			} else {
-				// connection successful, wait for context to be done
-				<-e.ctx.Done()
 				return nil
 			}
 		}
@@ -82,10 +80,14 @@ func (e *Engine) Run() error {
 
 func (e *Engine) getScannerEndpoints() ([]string, error) {
 	// make primary identity
-	ident, err := cloudflare.LoadOrCreateIdentity()
-	if err != nil {
-		log.Errorw("Failed to load/create primary identity", zap.Error(err))
-		return nil, err
+	ident := e.opts.Identity
+	if ident == nil {
+		var err error
+		ident, err = cloudflare.LoadOrCreateIdentity()
+		if err != nil {
+			log.Errorw("Failed to load/create primary identity", zap.Error(err))
+			return nil, err
+		}
 	}
 
 	// Reading the private key from the 'Interface' section
@@ -119,10 +121,14 @@ func (e *Engine) Stop() {
 
 func (e *Engine) runWarp(endpoint string) error {
 	// make primary identity
-	ident, err := cloudflare.LoadOrCreateIdentity()
-	if err != nil {
-		log.Errorw("Failed to load primary identity", zap.Error(err))
-		return err
+	ident := e.opts.Identity
+	if ident == nil {
+		var err error
+		ident, err = cloudflare.LoadOrCreateIdentity()
+		if err != nil {
+			log.Errorw("Failed to load primary identity", zap.Error(err))
+			return err
+		}
 	}
 
 	conf := GenerateWireguardConfig(ident)
@@ -148,9 +154,6 @@ func (e *Engine) runWarp(endpoint string) error {
 
 // startProxy starts the proxy servers and waits for the context to be done.
 func (e *Engine) startProxy(ctx context.Context, conf *wiresocks.Configuration, opts *wiresocks.ProxyConfig) error {
-	ctx, cancel := context.WithCancelCause(ctx)
-	defer cancel(nil)
-
 	ws, err := wiresocks.NewWireSocks(
 		wiresocks.WithContext(ctx),
 		wiresocks.WithWireguardConfig(conf),
@@ -160,13 +163,6 @@ func (e *Engine) startProxy(ctx context.Context, conf *wiresocks.Configuration, 
 		return err
 	}
 
-	go func() {
-		if err := ws.Run(); err != nil {
-			log.Errorw("Failed to to start proxy server", zap.Error(err))
-			cancel(err)
-		}
-	}()
-
 	if opts.SocksBindAddr != nil {
 		log.Infow("Serving Socks5 proxy", zap.Stringer("addr", opts.SocksBindAddr))
 	}
@@ -174,6 +170,9 @@ func (e *Engine) startProxy(ctx context.Context, conf *wiresocks.Configuration, 
 		log.Infow("Serving HTTP proxy", zap.Stringer("addr", opts.HttpBindAddr))
 	}
 
-	<-ctx.Done()
+	if err := ws.Run(); err != nil {
+		log.Errorw("Failed to start proxy server", zap.Error(err))
+		return err
+	}
 	return nil
 }

--- a/ipscanner/check.go
+++ b/ipscanner/check.go
@@ -1,0 +1,30 @@
+package ipscanner
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+
+	"github.com/shahradelahi/cloudflare-warp/ipscanner/model"
+	"github.com/shahradelahi/cloudflare-warp/ipscanner/ping"
+)
+
+// CheckEndpoint performs a WireGuard handshake with one exact WARP endpoint.
+func CheckEndpoint(ctx context.Context, endpoint netip.AddrPort, privateKey, peerPublicKey string) (IPInfo, error) {
+	if ctx == nil {
+		return IPInfo{}, errors.New("context is nil")
+	}
+	if !endpoint.IsValid() || endpoint.Port() == 0 {
+		return IPInfo{}, errors.New("invalid WARP endpoint")
+	}
+	if privateKey == "" || peerPublicKey == "" {
+		return IPInfo{}, errors.New("WARP keys are required")
+	}
+
+	options := &statute.ScannerOptions{
+		WarpPrivateKey:    privateKey,
+		WarpPeerPublicKey: peerPublicKey,
+		ScannerPorts:      []uint16{endpoint.Port()},
+	}
+	return ping.NewPinger(options).DoPing(ctx, endpoint.Addr())
+}

--- a/ipscanner/model/statute.go
+++ b/ipscanner/model/statute.go
@@ -27,6 +27,7 @@ type ScannerOptions struct {
 	IPQueueSize       int
 	IPQueueTTL        time.Duration
 	MaxDesirableRTT   time.Duration
+	ScannerPorts      []uint16
 	EventsHandler     EndpointEventHandler
 	Cache             *cache.Cache
 	Obfuscation       bool

--- a/ipscanner/ping/warp.go
+++ b/ipscanner/ping/warp.go
@@ -68,7 +68,10 @@ func (h *WarpPing) Ping() statute.IPingResult {
 }
 
 func (h *WarpPing) PingContext(ctx context.Context) statute.IPingResult {
-	ports := network.ScannerPorts()
+	ports := h.opts.ScannerPorts
+	if len(ports) == 0 {
+		ports = network.ScannerPorts()
+	}
 	results := make(chan statute.IPingResult, len(ports))
 	var wg sync.WaitGroup
 

--- a/ipscanner/scanner.go
+++ b/ipscanner/scanner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/netip"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -18,6 +19,8 @@ type IPScanner struct {
 	options statute.ScannerOptions
 	engine  *engine.Engine
 	ctx     context.Context
+	done    chan struct{}
+	mu      sync.RWMutex
 }
 
 func NewScanner(options ...Option) *IPScanner {
@@ -42,7 +45,8 @@ func NewScanner(options ...Option) *IPScanner {
 			IPQueueTTL:        30 * time.Second,
 			Cache:             c,
 		},
-		ctx: context.Background(),
+		ctx:  context.Background(),
+		done: make(chan struct{}),
 	}
 
 	for _, option := range options {
@@ -90,6 +94,14 @@ func WithMaxDesirableRTT(threshold time.Duration) Option {
 	}
 }
 
+// WithScannerPorts limits WARP handshake checks to the supplied UDP ports.
+// By default all known WARP ports are checked.
+func WithScannerPorts(ports ...uint16) Option {
+	return func(i *IPScanner) {
+		i.options.ScannerPorts = append([]uint16(nil), ports...)
+	}
+}
+
 func WithIPQueueTTL(ttl time.Duration) Option {
 	return func(i *IPScanner) {
 		i.options.IPQueueTTL = ttl
@@ -124,6 +136,7 @@ func WithCache(c *cache.Cache) Option {
 // cancel all operations
 
 func (i *IPScanner) Run() error {
+	defer close(i.done)
 	if !i.options.UseIPv4 && !i.options.UseIPv6 {
 		log.Fatal("Invalid configuration: Both IPv4 and IPv6 scanning are disabled. Please enable at least one to proceed.")
 		return nil
@@ -134,7 +147,9 @@ func (i *IPScanner) Run() error {
 		return errors.New("failed to create scanner engine")
 	}
 
+	i.mu.Lock()
 	i.engine = eng
+	i.mu.Unlock()
 	i.engine.Run()
 
 	if i.options.Cache != nil {
@@ -148,16 +163,25 @@ func (i *IPScanner) Run() error {
 }
 
 func (i *IPScanner) Stop() {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
 	if i.engine != nil {
 		i.engine.Shutdown()
 	}
 }
 
 func (i *IPScanner) GetAvailableIPs() []statute.IPInfo {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
 	if i.engine != nil {
 		return i.engine.GetAvailableIPs(false)
 	}
 	return nil
+}
+
+// Done is closed when Run exits.
+func (i *IPScanner) Done() <-chan struct{} {
+	return i.done
 }
 
 type IPInfo = statute.IPInfo

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -1,0 +1,100 @@
+// Package sdk provides an embeddable API for running one or more Cloudflare
+// WARP-backed proxy servers in a Go application.
+package sdk
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/shahradelahi/cloudflare-warp/cloudflare"
+	"github.com/shahradelahi/cloudflare-warp/cloudflare/model"
+	"github.com/shahradelahi/cloudflare-warp/core/datadir"
+)
+
+// ClientConfig controls WARP identity loading.
+type ClientConfig struct {
+	// DataDir contains reg.json and conf.json. Missing identity files are
+	// created automatically. The default is ~/.cloudflare-warp.
+	DataDir string
+
+	// Identity skips filesystem and Cloudflare API identity loading when set.
+	// This is useful when an application manages WARP credentials itself.
+	Identity *model.Identity
+}
+
+// Client owns a WARP identity and creates independent proxy instances.
+// A Client is safe for concurrent use.
+type Client struct {
+	identity *model.Identity
+	dataDir  string
+}
+
+// datadirMu protects the legacy global data directory while an identity is
+// loaded or created. Proxies use Client.identity after NewClient returns.
+var datadirMu sync.Mutex
+
+// NewClient loads or creates one WARP identity. Reuse the returned Client for
+// all proxies in an application to avoid duplicate registrations.
+func NewClient(config ClientConfig) (*Client, error) {
+	if config.Identity != nil {
+		if err := validateIdentity(config.Identity); err != nil {
+			return nil, err
+		}
+		return &Client{identity: config.Identity, dataDir: config.DataDir}, nil
+	}
+
+	dir := datadir.GetDataDirOrPath(config.DataDir)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return nil, fmt.Errorf("create WARP data directory: %w", err)
+	}
+
+	datadirMu.Lock()
+	defer datadirMu.Unlock()
+
+	datadir.SetDataDir(dir)
+	identity, err := cloudflare.LoadOrCreateIdentity()
+	if err != nil {
+		return nil, fmt.Errorf("load or create WARP identity: %w", err)
+	}
+	if err := validateIdentity(identity); err != nil {
+		return nil, err
+	}
+
+	return &Client{identity: identity, dataDir: dir}, nil
+}
+
+// GenerateIdentity loads an existing WARP identity from dataDir or generates
+// and saves a new one there when identity files do not exist.
+func GenerateIdentity(dataDir string) (*Client, error) {
+	if dataDir == "" {
+		return nil, errors.New("WARP identity data directory is required")
+	}
+	return NewClient(ClientConfig{DataDir: dataDir})
+}
+
+// DataDir returns the identity directory used by this client. It is empty when
+// ClientConfig.Identity was supplied without a directory.
+func (c *Client) DataDir() string {
+	if c == nil {
+		return ""
+	}
+	return c.dataDir
+}
+
+func validateIdentity(identity *model.Identity) error {
+	if identity == nil {
+		return errors.New("WARP identity is nil")
+	}
+	if identity.PrivateKey == "" {
+		return errors.New("WARP identity has no private key")
+	}
+	if len(identity.Config.Peers) == 0 {
+		return errors.New("WARP identity has no peers")
+	}
+	if identity.Config.Peers[0].PublicKey == "" {
+		return errors.New("WARP identity peer has no public key")
+	}
+	return nil
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,0 +1,148 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/shahradelahi/cloudflare-warp/cloudflare/model"
+)
+
+func testIdentity() *model.Identity {
+	return &model.Identity{
+		PrivateKey: "private-key",
+		Config: model.IdentityConfig{
+			Peers: []model.IdentityConfigPeer{{PublicKey: "public-key"}},
+		},
+	}
+}
+
+func TestNewProxyDefaults(t *testing.T) {
+	client, err := NewClient(ClientConfig{Identity: testIdentity()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy, err := client.NewProxy(context.Background(), ProxyConfig{
+		Port:       1080,
+		EndpointIP: netip.MustParseAddr("162.159.192.1"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := proxy.Addr().String(), "127.0.0.1:1080"; got != want {
+		t.Fatalf("Addr() = %q, want %q", got, want)
+	}
+	if got, want := proxy.Endpoint().String(), "162.159.192.1:2408"; got != want {
+		t.Fatalf("Endpoint() = %q, want %q", got, want)
+	}
+	if err := proxy.Wait(); !errors.Is(err, ErrNotStarted) {
+		t.Fatalf("Wait() error = %v, want %v", err, ErrNotStarted)
+	}
+	proxy.Stop()
+}
+
+func TestNewProxyValidation(t *testing.T) {
+	client, err := NewClient(ClientConfig{Identity: testIdentity()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name   string
+		config ProxyConfig
+	}{
+		{name: "missing port", config: ProxyConfig{EndpointIP: netip.MustParseAddr("162.159.192.1")}},
+		{name: "missing endpoint", config: ProxyConfig{Port: 1080}},
+		{name: "invalid protocol", config: ProxyConfig{Port: 1080, EndpointIP: netip.MustParseAddr("162.159.192.1"), Protocol: Protocol(10)}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := client.NewProxy(context.Background(), test.config); err == nil {
+				t.Fatal("NewProxy() error = nil, want validation error")
+			}
+		})
+	}
+}
+
+func TestNewClientValidatesIdentity(t *testing.T) {
+	_, err := NewClient(ClientConfig{Identity: &model.Identity{}})
+	if err == nil {
+		t.Fatal("NewClient() error = nil, want validation error")
+	}
+}
+
+func TestStopBeforeStart(t *testing.T) {
+	client, err := NewClient(ClientConfig{Identity: testIdentity()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy, err := client.NewProxy(context.Background(), ProxyConfig{
+		Port:       1080,
+		EndpointIP: netip.MustParseAddr("162.159.192.1"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proxy.Stop()
+	if err := proxy.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := proxy.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v, want nil", err)
+	}
+}
+
+func TestGenerateIdentityRequiresDirectory(t *testing.T) {
+	if _, err := GenerateIdentity(""); err == nil {
+		t.Fatal("GenerateIdentity() error = nil, want validation error")
+	}
+}
+
+func TestNormalizeScanOptions(t *testing.T) {
+	options := normalizeScanOptions(ScanOptions{})
+	if !options.IPv4 || !options.IPv6 {
+		t.Fatal("normalizeScanOptions() did not enable both address families")
+	}
+	if options.Limit != defaultScanLimit {
+		t.Fatalf("Limit = %d, want %d", options.Limit, defaultScanLimit)
+	}
+	if options.MaxRTT != defaultMaxRTT {
+		t.Fatalf("MaxRTT = %s, want %s", options.MaxRTT, defaultMaxRTT)
+	}
+	if options.Timeout != defaultScanTimeout {
+		t.Fatalf("Timeout = %s, want %s", options.Timeout, defaultScanTimeout)
+	}
+}
+
+func TestCheckEndpointValidation(t *testing.T) {
+	client, err := NewClient(ClientConfig{Identity: testIdentity()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.CheckEndpoint(context.Background(), netip.AddrPort{}); err == nil {
+		t.Fatal("CheckEndpoint() error = nil, want validation error")
+	}
+}
+
+func TestShutdownBeforeStart(t *testing.T) {
+	client, err := NewClient(ClientConfig{Identity: testIdentity()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy, err := client.NewProxy(context.Background(), ProxyConfig{
+		Port:       1080,
+		EndpointIP: netip.MustParseAddr("162.159.192.1"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := proxy.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error = %v, want nil", err)
+	}
+}

--- a/sdk/proxy.go
+++ b/sdk/proxy.go
@@ -1,0 +1,250 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"github.com/shahradelahi/cloudflare-warp/core"
+)
+
+const (
+	// DefaultEndpointPort is Cloudflare WARP's standard WireGuard port.
+	DefaultEndpointPort uint16 = 2408
+)
+
+var (
+	// ErrAlreadyStarted is returned when Run or Start is called twice.
+	ErrAlreadyStarted = errors.New("WARP proxy already started")
+	// ErrNotStarted is returned when Wait is called before Run or Start.
+	ErrNotStarted = errors.New("WARP proxy is not started")
+)
+
+// Protocol selects the local proxy protocol.
+type Protocol uint8
+
+const (
+	// SOCKS5 serves a SOCKS5 proxy. It is the default protocol.
+	SOCKS5 Protocol = iota
+	// HTTP serves an HTTP CONNECT proxy.
+	HTTP
+)
+
+// ProxyConfig describes one independent proxy and its WARP endpoint.
+type ProxyConfig struct {
+	// ListenIP is the local address accepting proxy connections. The default
+	// is 127.0.0.1. Set 0.0.0.0 or :: only when remote access is intended.
+	ListenIP netip.Addr
+	// Port is the local SOCKS5 or HTTP proxy port. It must be non-zero.
+	Port uint16
+	// EndpointIP is the remote Cloudflare WARP server IP used by this proxy.
+	EndpointIP netip.Addr
+	// EndpointPort is the remote WARP UDP port. The default is 2408.
+	EndpointPort uint16
+	// DNS is used inside the WARP tunnel. The default is 1.1.1.1.
+	DNS netip.Addr
+	// Protocol selects SOCKS5 or HTTP. The zero value is SOCKS5.
+	Protocol Protocol
+}
+
+// Proxy is one WARP tunnel with one local proxy listener.
+type Proxy struct {
+	engine   *core.Engine
+	cancel   context.CancelFunc
+	bindAddr netip.AddrPort
+	endpoint netip.AddrPort
+
+	mu       sync.RWMutex
+	started  bool
+	stopped  bool
+	err      error
+	done     chan struct{}
+	doneOnce sync.Once
+}
+
+// NewProxy creates, but does not start, an independent WARP proxy.
+func (c *Client) NewProxy(ctx context.Context, config ProxyConfig) (*Proxy, error) {
+	if c == nil || c.identity == nil {
+		return nil, errors.New("WARP client is not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New("context is nil")
+	}
+	if config.Port == 0 {
+		return nil, errors.New("proxy port must be non-zero")
+	}
+	if !config.EndpointIP.IsValid() {
+		return nil, errors.New("WARP endpoint IP is required")
+	}
+	if config.Protocol != SOCKS5 && config.Protocol != HTTP {
+		return nil, fmt.Errorf("unsupported proxy protocol: %d", config.Protocol)
+	}
+
+	if !config.ListenIP.IsValid() {
+		config.ListenIP = netip.MustParseAddr("127.0.0.1")
+	}
+	if config.EndpointPort == 0 {
+		config.EndpointPort = DefaultEndpointPort
+	}
+	if !config.DNS.IsValid() {
+		config.DNS = netip.MustParseAddr("1.1.1.1")
+	}
+
+	bindAddr := netip.AddrPortFrom(config.ListenIP, config.Port)
+	endpoint := netip.AddrPortFrom(config.EndpointIP, config.EndpointPort)
+	engineConfig := core.Config{
+		Endpoints:            []string{endpoint.String()},
+		DnsAddr:              config.DNS,
+		UserProvidedEndpoint: true,
+		Identity:             c.identity,
+	}
+	if config.Protocol == SOCKS5 {
+		engineConfig.SocksBindAddress = &bindAddr
+	} else {
+		engineConfig.HttpBindAddress = &bindAddr
+	}
+
+	proxyCtx, cancel := context.WithCancel(ctx)
+	return &Proxy{
+		engine:   core.NewEngine(proxyCtx, engineConfig),
+		cancel:   cancel,
+		bindAddr: bindAddr,
+		endpoint: endpoint,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start launches the proxy in a background goroutine. Startup and runtime
+// errors are returned by Wait. Use Run when the caller needs a blocking API.
+func (p *Proxy) Start() error {
+	if err := p.markStarted(); err != nil {
+		return err
+	}
+	go p.execute()
+	return nil
+}
+
+// Run starts the proxy and blocks until it stops or fails.
+func (p *Proxy) Run() error {
+	if err := p.markStarted(); err != nil {
+		return err
+	}
+	p.execute()
+	return p.result()
+}
+
+func (p *Proxy) markStarted() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return ErrAlreadyStarted
+	}
+	p.started = true
+	if p.stopped {
+		return nil
+	}
+	return nil
+}
+
+func (p *Proxy) execute() {
+	p.mu.RLock()
+	stopped := p.stopped
+	p.mu.RUnlock()
+	if stopped {
+		p.finish(nil)
+		return
+	}
+
+	err := p.engine.Run()
+	p.finish(err)
+}
+
+func (p *Proxy) finish(err error) {
+	p.mu.Lock()
+	p.err = err
+	p.mu.Unlock()
+	p.doneOnce.Do(func() { close(p.done) })
+}
+
+// Wait blocks until a proxy started with Start stops or fails. It is safe for
+// multiple goroutines to call Wait.
+func (p *Proxy) Wait() error {
+	p.mu.RLock()
+	started := p.started
+	p.mu.RUnlock()
+	if !started {
+		return ErrNotStarted
+	}
+	<-p.done
+	return p.result()
+}
+
+// WaitContext waits until the proxy exits or ctx is canceled.
+func (p *Proxy) WaitContext(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("context is nil")
+	}
+	p.mu.RLock()
+	started := p.started
+	p.mu.RUnlock()
+	if !started {
+		return ErrNotStarted
+	}
+	select {
+	case <-p.done:
+		return p.result()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Proxy) result() error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.err
+}
+
+// Stop gracefully stops this proxy without affecting other instances.
+func (p *Proxy) Stop() {
+	p.mu.Lock()
+	p.stopped = true
+	started := p.started
+	p.mu.Unlock()
+	p.cancel()
+	p.engine.Stop()
+	if !started {
+		p.finish(nil)
+	}
+}
+
+// Shutdown stops the proxy and waits for tunnel and listener shutdown. If ctx
+// expires first, its error is returned while shutdown continues in background.
+func (p *Proxy) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		return errors.New("context is nil")
+	}
+	p.Stop()
+	select {
+	case <-p.done:
+		return p.result()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Done is closed after the proxy stops or fails.
+func (p *Proxy) Done() <-chan struct{} {
+	return p.done
+}
+
+// Addr returns the local proxy listener address.
+func (p *Proxy) Addr() netip.AddrPort {
+	return p.bindAddr
+}
+
+// Endpoint returns the remote WARP endpoint used by this proxy.
+func (p *Proxy) Endpoint() netip.AddrPort {
+	return p.endpoint
+}

--- a/sdk/scanner.go
+++ b/sdk/scanner.go
@@ -1,0 +1,148 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"time"
+
+	"github.com/shahradelahi/cloudflare-warp/cloudflare/network"
+	"github.com/shahradelahi/cloudflare-warp/ipscanner"
+)
+
+const (
+	defaultScanLimit   = 2
+	defaultScanTimeout = time.Minute
+	defaultMaxRTT      = time.Second
+)
+
+// ErrNoEndpoints is returned when a scan finds no usable WARP endpoint.
+var ErrNoEndpoints = errors.New("no usable WARP endpoints found")
+
+// Endpoint is a WARP server verified with a WireGuard handshake.
+type Endpoint struct {
+	AddrPort netip.AddrPort
+	RTT      time.Duration
+}
+
+// ScanOptions controls WARP endpoint discovery.
+type ScanOptions struct {
+	// IPv4 and IPv6 select address families. When both are false, both are used.
+	IPv4 bool
+	IPv6 bool
+	// Limit is the number of best endpoints to return. The default is 2.
+	Limit int
+	// MaxRTT rejects slower endpoints. The default is one second.
+	MaxRTT time.Duration
+	// Timeout limits the whole scan. The default is one minute. Partial results
+	// are returned without an error when timeout expires after finding any.
+	Timeout time.Duration
+}
+
+// Scan discovers WARP endpoints, verifies them with WireGuard handshakes, and
+// returns results ordered from lowest to highest RTT.
+func (c *Client) Scan(ctx context.Context, options ScanOptions) ([]Endpoint, error) {
+	if c == nil || c.identity == nil {
+		return nil, errors.New("WARP client is not initialized")
+	}
+	if ctx == nil {
+		return nil, errors.New("context is nil")
+	}
+
+	options = normalizeScanOptions(options)
+	scanCtx, cancel := context.WithTimeout(ctx, options.Timeout)
+	defer cancel()
+
+	scanner := ipscanner.NewScanner(
+		ipscanner.WithContext(scanCtx),
+		ipscanner.WithWarpPrivateKey(c.identity.PrivateKey),
+		ipscanner.WithWarpPeerPublicKey(c.identity.Config.Peers[0].PublicKey),
+		ipscanner.WithUseIPv4(options.IPv4),
+		ipscanner.WithUseIPv6(options.IPv6),
+		ipscanner.WithMaxDesirableRTT(options.MaxRTT),
+		ipscanner.WithIPQueueSize(options.Limit),
+		ipscanner.WithCidrList(network.ScannerPrefixes()),
+		ipscanner.WithCache(nil),
+	)
+	runDone := make(chan error, 1)
+	go func() { runDone <- scanner.Run() }()
+	defer scanner.Stop()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			scanner.Stop()
+			<-scanner.Done()
+			return nil, ctx.Err()
+		case <-scanCtx.Done():
+			return stopScanner(scanner, options.Limit)
+		case err := <-runDone:
+			if err != nil {
+				return nil, err
+			}
+			return scanResults(scanner, options.Limit)
+		case <-ticker.C:
+			if len(scanner.GetAvailableIPs()) >= options.Limit {
+				return stopScanner(scanner, options.Limit)
+			}
+		}
+	}
+}
+
+func stopScanner(scanner *ipscanner.IPScanner, limit int) ([]Endpoint, error) {
+	scanner.Stop()
+	<-scanner.Done()
+	return scanResults(scanner, limit)
+}
+
+func normalizeScanOptions(options ScanOptions) ScanOptions {
+	if !options.IPv4 && !options.IPv6 {
+		options.IPv4, options.IPv6 = true, true
+	}
+	if options.Limit <= 0 {
+		options.Limit = defaultScanLimit
+	}
+	if options.MaxRTT <= 0 {
+		options.MaxRTT = defaultMaxRTT
+	}
+	if options.Timeout <= 0 {
+		options.Timeout = defaultScanTimeout
+	}
+	return options
+}
+
+func scanResults(scanner *ipscanner.IPScanner, limit int) ([]Endpoint, error) {
+	available := scanner.GetAvailableIPs()
+	if len(available) == 0 {
+		return nil, ErrNoEndpoints
+	}
+	if len(available) > limit {
+		available = available[:limit]
+	}
+	result := make([]Endpoint, len(available))
+	for index, info := range available {
+		result[index] = Endpoint{AddrPort: info.AddrPort, RTT: info.RTT}
+	}
+	return result, nil
+}
+
+// CheckEndpoint verifies one exact IP and UDP port with a WARP WireGuard
+// handshake and returns measured RTT.
+func (c *Client) CheckEndpoint(ctx context.Context, endpoint netip.AddrPort) (Endpoint, error) {
+	if c == nil || c.identity == nil {
+		return Endpoint{}, errors.New("WARP client is not initialized")
+	}
+	info, err := ipscanner.CheckEndpoint(
+		ctx,
+		endpoint,
+		c.identity.PrivateKey,
+		c.identity.Config.Peers[0].PublicKey,
+	)
+	if err != nil {
+		return Endpoint{}, err
+	}
+	return Endpoint{AddrPort: info.AddrPort, RTT: info.RTT}, nil
+}


### PR DESCRIPTION
This PR adds an sdk for embedding cloudflare WARP proxies into go applications.
It supports identity generation, endpoint scanning, custom proxy ports and WARP endpoints, multiple concurrent proxy instances, and graceful shutdown.
What do you think?